### PR TITLE
ci: pin peter-evans/dockerhub-description

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@e98e4d1628a5f3be2be7c231e50981aee98723ae
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PUSH_TOKEN }}


### PR DESCRIPTION
In the wake of the recent supply chain attacks on GitHub actions ([1],[2]), we should follow best practices and pin any third party actions by their commit hash, e.g. all those that area neither `actions/*` nor `docker/*`.

See GitHub's official documentation ([3]) for the recommendation.

[1]: https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066
[2]: https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup
[3]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions