### PR TITLE
fix: allow more parameters to be passed through

### DIFF
--- a/run-prtgmpprobe.sh
+++ b/run-prtgmpprobe.sh
@@ -13,7 +13,7 @@ _passthrough=0
 for _arg in "$@"
 do
     case "$_arg" in
-        --help|example-config)
+        -h|--help|example-config|-V|--version)
             _passthrough=1
         ;;
     esac


### PR DESCRIPTION
allow short form of --help (-h) and also --version (-V) to be directly used