### PR TITLE
feat: update base image to Debian 13 (Trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11-slim
+FROM debian:13-slim
 
 LABEL org.opencontainers.image.authors="info@paessler.com"
 LABEL org.opencontainers.image.vendor="Paessler GmbH"


### PR DESCRIPTION
Debian 13 is officially supported as of Multi-Platform Probe 3.8

closes #10 