### PR TITLE
Pin paessler_mpprobe to a stable UID/GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,14 @@ LABEL org.opencontainers.image.licenses="MIT"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# Pre-create the probe user with a preset but overridable UID/GID
+ARG PRTGMPPROBE__LINUX_UID=999
+ARG PRTGMPPROBE__LINUX_GID=999
+RUN groupadd --system --gid "${PRTGMPPROBE__LINUX_GID}" paessler_mpprobe \
+ && useradd --system --uid "${PRTGMPPROBE__LINUX_UID}" \
+      --gid paessler_mpprobe --home-dir /var/opt/paessler/mpprobe \
+      --shell /usr/sbin/nologin --no-create-home paessler_mpprobe
+
 # enforce image to be up to date
 RUN \
     apt-get update \

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ While the container provides some defaults, we recommend that you change the fol
 | -- | -- | -- |
 | `PRTGMPPROBE__NAME` | The name of the object shown in PRTG. | `multi-platform-probe@$(hostname)` |
 | `PRTGMPPROBE__ID` | The GID of the multi-platform probe. This must be a valid UUIDv4. The container automatically generates the GID when you create it and stores the GID in the `/config` volume. If you want to ensure that you always get the same UUIDv4, then we recommend that you use `uuidgen(1)` with a unique DNS string for your container, e.g. `uuidgen --namespace @dns --name com.paesslerfans.containers.acme --sha1`. | Randomly generated on the first run. |
+| `PRTGMPPROBE__LINUX_UID` | The Linux User ID for `paessler_mpprobe` that service runs as and files are owned by. | `999` |
+| `PRTGMPPROBE__LINUX_GID` | The Linux Group ID for `paessler_mpprobe` that service runs as and files are owned by. | `999` |
 
 ## Feedback and issues
 


### PR DESCRIPTION
The probe user is currently created by the prtgmpprobe postinst without a specific allocated system UID, so the runtime UID can change between image releases (it recently did). Anyone bind-mounting /config with restrictive permissions (especially rootless Podman/Docker users mapping ownership through user namespaces) has their deployment break on image upgrade with 'Failed to read config file: Permission denied'. This pre-creates the service account user/group with a fixed, build-arg-overridable UID/GID (default 999) before package installation so the postinst adopts it, and documents the value in the README. Verified the postinst adopts an existing user; entrypoint gosu drop unaffected.